### PR TITLE
PAYM-520 adjust scraping for PowerDNS 4.3

### DIFF
--- a/test/authoritative_stats.json
+++ b/test/authoritative_stats.json
@@ -5,12 +5,32 @@
     "value": "0"
   },
   {
+    "name": "cpu-iowait",
+    "type": "StatisticItem",
+    "value": "507"
+  },
+  {
+    "name": "cpu-steal",
+    "type": "StatisticItem",
+    "value": "0"
+  },
+  {
     "name": "deferred-cache-inserts",
     "type": "StatisticItem",
     "value": "0"
   },
   {
     "name": "deferred-cache-lookup",
+    "type": "StatisticItem",
+    "value": "0"
+  },
+  {
+    "name": "deferred-packetcache-inserts",
+    "type": "StatisticItem",
+    "value": "0"
+  },
+  {
+    "name": "deferred-packetcache-lookup",
     "type": "StatisticItem",
     "value": "0"
   },
@@ -118,6 +138,96 @@
     "name": "recursion-unanswered",
     "type": "StatisticItem",
     "value": "0"
+  },
+  {
+    "name": "ring-logmessages-capacity",
+    "type": "StatisticItem",
+    "value": "10000"
+  },
+  {
+    "name": "ring-logmessages-size",
+    "type": "StatisticItem",
+    "value": "9"
+  },
+  {
+    "name": "ring-noerror-queries-capacity",
+    "type": "StatisticItem",
+    "value": "10000"
+  },
+  {
+    "name": "ring-noerror-queries-size",
+    "type": "StatisticItem",
+    "value": "0"
+  },
+  {
+    "name": "ring-nxdomain-queries-capacity",
+    "type": "StatisticItem",
+    "value": "10000"
+  },
+  {
+    "name": "ring-nxdomain-queries-size",
+    "type": "StatisticItem",
+    "value": "0"
+  },
+  {
+    "name": "ring-queries-capacity",
+    "type": "StatisticItem",
+    "value": "10000"
+  },
+  {
+    "name": "ring-queries-size",
+    "type": "StatisticItem",
+    "value": "1"
+  },
+  {
+    "name": "ring-remotes-capacity",
+    "type": "StatisticItem",
+    "value": "10000"
+  },
+  {
+    "name": "ring-remotes-corrupt-capacity",
+    "type": "StatisticItem",
+    "value": "10000"
+  },
+  {
+    "name": "ring-remotes-corrupt-size",
+    "type": "StatisticItem",
+    "value": "0"
+  },
+  {
+    "name": "ring-remotes-size",
+    "type": "StatisticItem",
+    "value": "1"
+  },
+  {
+    "name": "ring-remotes-unauth-capacity",
+    "type": "StatisticItem",
+    "value": "10000"
+  },
+  {
+    "name": "ring-remotes-unauth-size",
+    "type": "StatisticItem",
+    "value": "1"
+  },
+  {
+    "name": "ring-servfail-queries-capacity",
+    "type": "StatisticItem",
+    "value": "10000"
+  },
+  {
+    "name": "ring-servfail-queries-size",
+    "type": "StatisticItem",
+    "value": "0"
+  },
+  {
+    "name": "ring-unauth-queries-capacity",
+    "type": "StatisticItem",
+    "value": "10000"
+  },
+  {
+    "name": "ring-unauth-queries-size",
+    "type": "StatisticItem",
+    "value": "1"
   },
   {
     "name": "security-status",
@@ -273,5 +383,122 @@
     "name": "user-msec",
     "type": "StatisticItem",
     "value": "1877"
+  },
+  {
+    "name": "response-by-qtype",
+    "type": "MapStatisticItem",
+    "value": [
+      {
+        "name": "A",
+        "value": "1"
+      }
+    ]
+  },
+  {
+    "name": "response-sizes",
+    "type": "MapStatisticItem",
+    "value": [
+      {
+        "name": "20",
+        "value": "1"
+      }
+    ]
+  },
+  {
+    "name": "response-by-rcode",
+    "type": "MapStatisticItem",
+    "value": [
+      {
+        "name": "Query Refused",
+        "value": "1"
+      }
+    ]
+  },
+  {
+    "name": "logmessages",
+    "size": "10000",
+    "type": "RingStatisticItem",
+    "value": [
+      {
+        "name": "Backend launched with banner: OK\tJimdo DNS Backend Ready",
+        "value": "4"
+      },
+      {
+        "name": "Unable to resolve dolphin-remote-backend: Name or service not known",
+        "value": "4"
+      },
+      {
+        "name": "Creating backend connection for TCP",
+        "value": "1"
+      }
+    ]
+  },
+  {
+    "name": "remotes",
+    "size": "10000",
+    "type": "RingStatisticItem",
+    "value": [
+      {
+        "name": "192.168.59.3",
+        "value": "1"
+      }
+    ]
+  },
+  {
+    "name": "remotes-corrupt",
+    "size": "10000",
+    "type": "RingStatisticItem",
+    "value": []
+  },
+  {
+    "name": "remotes-unauth",
+    "size": "10000",
+    "type": "RingStatisticItem",
+    "value": [
+      {
+        "name": "192.168.59.3",
+        "value": "1"
+      }
+    ]
+  },
+  {
+    "name": "noerror-queries",
+    "size": "10000",
+    "type": "RingStatisticItem",
+    "value": []
+  },
+  {
+    "name": "nxdomain-queries",
+    "size": "10000",
+    "type": "RingStatisticItem",
+    "value": []
+  },
+  {
+    "name": "queries",
+    "size": "10000",
+    "type": "RingStatisticItem",
+    "value": [
+      {
+        "name": "pkg.go.dev/A",
+        "value": "1"
+      }
+    ]
+  },
+  {
+    "name": "servfail-queries",
+    "size": "10000",
+    "type": "RingStatisticItem",
+    "value": []
+  },
+  {
+    "name": "unauth-queries",
+    "size": "10000",
+    "type": "RingStatisticItem",
+    "value": [
+      {
+        "name": "pkg.go.dev/A",
+        "value": "1"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Context: From PowerDNS 4.1 onwards, the PowerDNS API returns also RingStatisticItem and MapStatisticItem (in addition to StatisticItem). The current implementation for the JSON parsing can not handle these new types, since they are not float values.